### PR TITLE
fix: broken command loader

### DIFF
--- a/src/handlers/commandHandler.ts
+++ b/src/handlers/commandHandler.ts
@@ -132,13 +132,6 @@ export default class CommandHandler {
           2,
         ),
       );
-      const topCommandData = this.commandsArray.find(
-        (cmd) => cmd.name === "top",
-      );
-      console.log(
-        "/top command data being sent:",
-        JSON.stringify(topCommandData, null, 2),
-      );
 
       await rest.put(Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID), {
         body: this.commandsArray,

--- a/src/handlers/commandHandler.ts
+++ b/src/handlers/commandHandler.ts
@@ -6,6 +6,7 @@ import {
   type ContextMenuCommandInteraction,
   MessageFlags,
   type PermissionResolvable,
+  PermissionsBitField,
   REST,
   type RESTPostAPIApplicationCommandsJSONBody,
   Routes,
@@ -15,6 +16,7 @@ import type { Client as ExarotonClient } from "exaroton";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { config } from "../config/env.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -47,7 +49,7 @@ const getFiles = (dir: string): string[] => {
   for (const file of files) {
     if (file.isDirectory()) {
       commandFiles = [...commandFiles, ...getFiles(path.join(dir, file.name))];
-    } else if (file.name.endsWith(".js") || file.name.endsWith(".ts")) {
+    } else if (file.name === "index.js" || file.name === "index.ts") {
       commandFiles.push(path.join(dir, file.name));
     }
   }
@@ -78,15 +80,28 @@ export default class CommandHandler {
           const commandFiles = getFiles(typePath);
 
           for (const file of commandFiles) {
-            const commandModule = await import(`file://${file}`);
-            const command: Command = commandModule.default;
+            try {
+              const commandModule = await import(`file://${file}`);
+              if (!commandModule.default?.data) {
+                console.warn(
+                  `[WARNING] File ${file} seems to be an index file but lacks a proper default export with a 'data' property. Skipping.`,
+                );
+                continue;
+              }
+              const command: Command = commandModule.default;
 
-            this.commands.set(command.data.name, command);
-            this.commandsArray.push(command.data.toJSON());
-            const commandType = type.charAt(0).toUpperCase() + type.slice(1);
-            console.log(
-              `Loaded [${commandType}] command: ${command.data.name}`,
-            );
+              this.commands.set(command.data.name, command);
+              this.commandsArray.push(command.data.toJSON());
+              const commandType = type.charAt(0).toUpperCase() + type.slice(1);
+              console.log(
+                `Loaded [${commandType}] command: ${command.data.name}`,
+              );
+            } catch (importError) {
+              console.error(
+                `Error importing command file ${file}:`,
+                importError,
+              );
+            }
           }
         }
       }
@@ -108,6 +123,22 @@ export default class CommandHandler {
 
       console.log("Refreshing application (/) commands.");
       const rest = new REST({ version: "10" }).setToken(TOKEN);
+      console.log("Attempting to register the following commands JSON:");
+      console.log(
+        JSON.stringify(
+          this.commandsArray,
+          (_key, value) =>
+            typeof value === "bigint" ? value.toString() : value,
+          2,
+        ),
+      );
+      const topCommandData = this.commandsArray.find(
+        (cmd) => cmd.name === "top",
+      );
+      console.log(
+        "/top command data being sent:",
+        JSON.stringify(topCommandData, null, 2),
+      );
 
       await rest.put(Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID), {
         body: this.commandsArray,
@@ -115,7 +146,13 @@ export default class CommandHandler {
 
       console.log("Successfully reloaded application (/) commands.");
     } catch (error) {
-      console.error("Error registering commands:", error);
+      console.error("!!! FAILED to register commands:", error);
+      if (error && typeof error === "object" && "rawError" in error) {
+        console.error(
+          "Discord API Raw Error:",
+          JSON.stringify((error as { rawError: unknown }).rawError, null, 2),
+        );
+      }
     }
   }
 
@@ -131,6 +168,69 @@ export default class CommandHandler {
     }
 
     try {
+      if (command.ownerOnly && interaction.user.id !== config.ids.owner) {
+        interaction.reply({
+          content:
+            "このコマンドを使用する権限がありません。\nYou are not authorized to use this command.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      if (
+        command.adminOnly &&
+        interaction.inGuild() &&
+        !(
+          interaction.member?.permissions instanceof PermissionsBitField &&
+          interaction.member.permissions.has(
+            PermissionsBitField.Flags.Administrator,
+          )
+        )
+      ) {
+        interaction.reply({
+          content:
+            "このコマンドは管理者のみが使用できます。\nOnly administrators can use this command.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      if (
+        command.allowedChannels?.length &&
+        interaction.inGuild() &&
+        interaction.channelId
+      ) {
+        const requiredChannelIds = command.allowedChannels
+          .map((key) => config.channels[key as keyof typeof config.channels])
+          .filter(Boolean);
+        if (!requiredChannelIds.includes(interaction.channelId)) {
+          const allowedChannelsMentions = requiredChannelIds
+            .map((id) => `<#${id}>`)
+            .join("、");
+          interaction.reply({
+            content: `このコマンドはこのチャンネルでは使用できません。${allowedChannelsMentions} で使用してください。`,
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+      }
+      if (
+        command.requiredPermissions?.length &&
+        interaction.inGuild() &&
+        interaction.member?.permissions instanceof PermissionsBitField
+      ) {
+        const missingPerms = interaction.member.permissions.missing(
+          command.requiredPermissions,
+        );
+        if (missingPerms.length > 0) {
+          interaction.reply({
+            content: `このコマンドを使用するには、次の権限が必要です: ${missingPerms.join(", ")}\nYou are missing the following permissions to use this command: ${missingPerms.join(", ")}`,
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+      }
+
       command.execute(interaction, this.client, this.options);
     } catch (error) {
       console.error(`Error executing ${interaction.commandName}:`, error);


### PR DESCRIPTION
## Outline

### Summary

Centralized command pre-execution checks for permissions, ownership, and channels into the `commandHandler`. The command loader now only targets `index` files and includes additional logging for registration failures.

### Changes & Enhancements

*   **Type of Change:**
    *   [ ] Feature
    *   [ ] Bugfix
    *   [x] Refactor
    *   [x] Chore

*   **Changes:**
    *   **(Handler: commandHandler):**
        *   Added pre-execution checks for `ownerOnly`, `adminOnly`, `allowedChannels`, and `requiredPermissions`.
        *   Command loader now discovers only `index.js` and `index.ts` files and skips invalid command exports.
        *   Added logging for the JSON payload and raw Discord API errors during command registration.

***

### Not Doing

-   Removing redundant permission checks from individual commands.

***

## Checklists

-   [ ] Code is well-documented (comments, JSDoc, etc.).
-   [ ] Existing comments were updated as needed.
-   [x] No out-of-scope changes are included.
-   [ ] Write TODO comments where future work is required.
-   [x] Removed unnecessary debug code (e.g., `console.log`, `debugger`).
-   [x] Self-reviewed and tested locally.