### PR TITLE
refactor: centralize string constants

### DIFF
--- a/src/commands/message/adminonly/purgeto/index.ts
+++ b/src/commands/message/adminonly/purgeto/index.ts
@@ -13,6 +13,7 @@ import {
   PermissionsBitField,
 } from "discord.js";
 import { Colors } from "../../../../constants/Colors.js";
+import { Strings } from "../../../../constants/Strings.js";
 import { createMenuCommand } from "../../../../utils/builders/menuCommandBuilder.js";
 
 const FOURTEEN_DAYS_IN_MS = 1000 * 60 * 60 * 24 * 14;
@@ -33,8 +34,7 @@ export default createMenuCommand(
       !interaction.channel.isTextBased()
     ) {
       await interaction.editReply({
-        content:
-          "このコマンドはサーバーのテキストチャンネルでのみ使用できます。\nThis command can only be used in a server text channel.",
+        content: Strings.Replies.GuildOnly,
       });
       return;
     }
@@ -46,8 +46,10 @@ export default createMenuCommand(
       )
     ) {
       await interaction.editReply({
-        content:
-          "ボットに「メッセージの管理」権限がありません。\nI don't have the 'Manage Messages' permission to perform this action.",
+        content: Strings.Permissions.BotMissing(
+          "メッセージの管理",
+          "Manage Messages",
+        ),
       });
       return;
     }
@@ -91,8 +93,7 @@ export default createMenuCommand(
     } catch (error) {
       console.error("Error during message fetching for purge:", error);
       await interaction.editReply({
-        content:
-          "メッセージの取得中にエラーが発生しました。\nAn error occurred while fetching messages.",
+        content: Strings.Errors.FetchMessages,
       });
       return;
     }
@@ -196,9 +197,7 @@ export default createMenuCommand(
       const timedOutEmbed = new EmbedBuilder()
         .setColor(Colors.yellow)
         .setTitle("タイムアウト / Timed Out")
-        .setDescription(
-          "15秒以内に確認が取れなかったため、キャンセルしました。\nConfirmation not received within 15 seconds, canceling.",
-        );
+        .setDescription(Strings.Replies.ConfirmationTimeout);
 
       const timedOutRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
         confirmButton.setDisabled(true),

--- a/src/commands/slash/adminonly/purge/index.ts
+++ b/src/commands/slash/adminonly/purge/index.ts
@@ -6,6 +6,7 @@ import {
   type SlashCommandBuilder,
   type Snowflake,
 } from "discord.js";
+import { Strings } from "../../../../constants/Strings.js";
 import { createCommand } from "../../../../utils/builders/commandBuilder.js";
 
 const FOURTEEN_DAYS_IN_MS = 1000 * 60 * 60 * 24 * 14;
@@ -22,8 +23,10 @@ export default createCommand(
       )
     ) {
       await interaction.editReply({
-        content:
-          "BOTに「メッセージの管理」権限がありません。\nI don't have the 'Manage Messages' permission to perform this action.",
+        content: Strings.Permissions.BotMissing(
+          "メッセージの管理",
+          "Manage Messages",
+        ),
       });
       return;
     }
@@ -81,8 +84,7 @@ export default createCommand(
       } catch (error) {
         console.error("Error fetching messages for purge by link:", error);
         await interaction.editReply({
-          content:
-            "メッセージの取得中にエラーが発生しました。\nAn error occurred while fetching messages.",
+          content: Strings.Errors.FetchMessages,
         });
         return;
       }
@@ -103,8 +105,7 @@ export default createCommand(
       } catch (error) {
         console.error("Error fetching messages for purge by amount:", error);
         await interaction.editReply({
-          content:
-            "メッセージの取得中にエラーが発生しました。\nAn error occurred while fetching messages.",
+          content: Strings.Errors.FetchMessages,
         });
         return;
       }
@@ -140,8 +141,7 @@ export default createCommand(
     } catch (error) {
       console.error("Error during bulk delete:", error);
       await interaction.editReply({
-        content:
-          "メッセージの削除中にエラーが発生しました。\nAn error occurred while deleting messages.",
+        content: Strings.Errors.DeleteMessages,
       });
     }
   },

--- a/src/commands/slash/management/listunverified/index.ts
+++ b/src/commands/slash/management/listunverified/index.ts
@@ -9,6 +9,7 @@ import { config } from "../../../../config/env.js";
 
 import { Colors } from "../../../../constants/Colors.js";
 
+import { Strings } from "../../../../constants/Strings.js";
 import { createCommand } from "../../../../utils/builders/commandBuilder.js";
 import {
   generatePage,
@@ -54,7 +55,7 @@ export default createCommand(
       const verifiedRoleId = config.roles.verified;
       if (!verifiedRoleId) {
         await interaction.editReply(
-          "`VERIFIED_ROLE_ID` が設定されていません。\nThe VERIFIED_ROLE_ID environment variable is not set.",
+          Strings.Errors.ConfigNotSet("VERIFIED_ROLE_ID"),
         );
         return;
       }
@@ -62,9 +63,7 @@ export default createCommand(
 
       const botMember = guild.members.me;
       if (!botMember?.permissions.has(PermissionsBitField.Flags.ViewChannel)) {
-        await interaction.editReply(
-          "BOTにチャンネルの閲覧権限がないため、メンバーをリストできません。\nThe bot does not have permission to view channels, thus cannot list members.",
-        );
+        await interaction.editReply(Strings.Permissions.BotViewChannel);
         return;
       }
       await guild.members.fetch();

--- a/src/commands/slash/minecraft/statusserver/index.ts
+++ b/src/commands/slash/minecraft/statusserver/index.ts
@@ -1,5 +1,6 @@
 import { EmbedBuilder } from "discord.js";
 import { Colors } from "../../../../constants/Colors.js";
+import { Strings } from "../../../../constants/Strings.js";
 import type { HandlerOptions } from "../../../../handlers/commandHandler.js";
 import { createCommand } from "../../../../utils/builders/commandBuilder.js";
 
@@ -70,7 +71,7 @@ export default createCommand(
       await interaction.editReply({ embeds: [embed] });
     } catch (error) {
       console.error("Error fetching server status:", error);
-      await interaction.editReply("サーバー情報の取得に失敗しました。");
+      await interaction.editReply(Strings.Errors.FetchServerInfo);
     }
   },
 );

--- a/src/commands/slash/minecraft/whitelist/index.ts
+++ b/src/commands/slash/minecraft/whitelist/index.ts
@@ -1,5 +1,6 @@
 import { EmbedBuilder } from "discord.js";
 import { Colors } from "../../../../constants/Colors.js";
+import { Strings } from "../../../../constants/Strings.js";
 import type { HandlerOptions } from "../../../../handlers/commandHandler.js";
 import { createCommand } from "../../../../utils/builders/commandBuilder.js";
 
@@ -16,7 +17,7 @@ type ExarotonError = {
  */
 const parseExarotonError = (error: unknown) => {
   const err = error as ExarotonError;
-  let errorMessage = err.message || "An unknown error occurred.";
+  let errorMessage = err.message || Strings.Errors.Unknown;
 
   const parseBody = (body: string) => {
     try {

--- a/src/constants/Strings.ts
+++ b/src/constants/Strings.ts
@@ -1,0 +1,32 @@
+export const Strings = {
+  Errors: {
+    Generic: "エラーが発生しました。\nAn error occurred.",
+    Unknown: "不明なエラーが発生しました。\nAn unknown error occurred.",
+    FetchMessages:
+      "メッセージの取得中にエラーが発生しました。\nAn error occurred while fetching messages.",
+    DeleteMessages:
+      "メッセージの削除中にエラーが発生しました。\nAn error occurred while deleting messages.",
+    FetchServerInfo:
+      "サーバー情報の取得に失敗しました。\nFailed to fetch server info.",
+    ConfigNotSet: (variable: string) =>
+      `\`${variable}\` が設定されていません。\nThe \`${variable}\` environment variable is not set.`,
+  },
+
+  Permissions: {
+    UserMissing:
+      "このコマンドを使用する権限がありません。\nYou are not authorized to use this command.",
+    BotMissing: (jp: string, en: string) =>
+      `ボットに「${jp}」権限がありません。\nI don't have the '${en}' permission to perform this action.`,
+    BotViewChannel:
+      "BOTにチャンネルの閲覧権限がないため、操作を実行できません。\nThe bot does not have permission to view channels, thus cannot perform this action.",
+  },
+
+  Replies: {
+    GuildOnly:
+      "このコマンドはサーバーのテキストチャンネルでのみ使用できます。\nThis command can only be used in a server text channel.",
+    ApprovalTimeout:
+      "タイムアウトまたは承認不足のため、操作をキャンセルしました。\nOperation canceled due to timeout or insufficient approvals.",
+    ConfirmationTimeout:
+      "15秒以内に確認が取れなかったため、キャンセルしました。\nConfirmation not received within 15 seconds, canceling.",
+  },
+};

--- a/src/utils/helpers/approvalHelper.ts
+++ b/src/utils/helpers/approvalHelper.ts
@@ -4,6 +4,7 @@ import type {
   MessageReaction,
   User,
 } from "discord.js";
+import { Strings } from "../../constants/Strings.js";
 
 export const handleApprovalProcess = async (
   interaction: CommandInteraction,
@@ -48,13 +49,11 @@ export const handleApprovalProcess = async (
           await pollMessage.reply(failureMessage);
         }
       } else {
-        await pollMessage.reply(
-          "タイムアウトまたは承認不足のため、操作をキャンセルしました。",
-        );
+        await pollMessage.reply(Strings.Replies.ApprovalTimeout);
       }
     });
   } catch (error) {
     console.error(error);
-    await interaction.editReply("エラーが発生しました。");
+    await interaction.editReply(Strings.Errors.Generic);
   }
 };


### PR DESCRIPTION
## Outline

### Summary

Refactor commands and helpers to use centralized string constants for user-facing messages.  
Introduce a new `Strings.ts` file to store these constants.

---

### Changes & Enhancements

**Type of Change:**
- [ ] Feature  
- [ ] Bugfix  
- [x] Refactor  
- [ ] Chore  

**Changes:**
- **(Constant: Strings):**
  - Add a new file to centralize user-facing strings for errors, permissions, and replies.
- **(Command: purgeto):**
  - Replace hardcoded messages with constants from `Strings`.
- **(Command: purge):**
  - Replace hardcoded error messages with constants from `Strings`.
- **(Command: listunverified):**
  - Replace hardcoded error and permission messages with constants from `Strings`.
- **(Command: statusserver):**
  - Replace a hardcoded error message with a constant from `Strings`.
- **(Command: whitelist):**
  - Replace a hardcoded error message with a constant from `Strings`.
- **(Helper: approvalHelper):**
  - Replace hardcoded reply and error messages with constants from `Strings`.

---

### Not Doing

---

### Other (Remarks)

---

## Checklists

- [ ] Code is well-documented (comments, JSDoc, etc.)  
- [ ] Existing comments were updated as needed  
- [x] No out-of-scope changes are included  
- [ ] Write TODO comments where future work is required  
- [ ] Removed unnecessary debug code (e.g., `console.log`, `debugger`)  
- [x] Self-reviewed and tested locally
