### PR TITLE
fix: session calculation

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -6,6 +6,7 @@ import {
   pgTable,
   primaryKey,
   real,
+  serial,
   text,
   timestamp,
 } from "drizzle-orm/pg-core";
@@ -88,5 +89,31 @@ export const hourlyActivity = pgTable(
   },
   (table) => ({
     pk: primaryKey({ columns: [table.date, table.hour] }),
+  }),
+);
+
+export const voiceSessions = pgTable("voice_sessions", {
+  id: serial("id").primaryKey(),
+  channelId: text("channel_id")
+    .references(() => channels.id)
+    .notNull(),
+  startTime: timestamp("start_time", { withTimezone: true }).notNull(),
+  endTime: timestamp("end_time", { withTimezone: true }),
+  durationSeconds: integer("duration_seconds"),
+  totalUniqueParticipants: integer("total_unique_participants"),
+});
+
+export const voiceSessionParticipants = pgTable(
+  "voice_session_participants",
+  {
+    sessionId: integer("session_id")
+      .references(() => voiceSessions.id)
+      .notNull(),
+    userId: text("user_id")
+      .references(() => users.id)
+      .notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.sessionId, table.userId] }),
   }),
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,12 @@ import {
   GatewayIntentBits,
   type Interaction,
 } from "discord.js";
+import { eq, isNull } from "drizzle-orm";
 import { Client as ExarotonClient } from "exaroton";
 import { config } from "./config/env.js";
 import { Colors } from "./constants/Colors.js";
 import { db } from "./db/index.js";
-import { activeVcSessions } from "./db/schema.js";
+import { activeVcSessions, voiceSessions } from "./db/schema.js";
 import CommandHandler from "./handlers/commandHandler.js";
 import InteractionHandler from "./handlers/interactionHandler.js";
 import ListenerHandler from "./handlers/listenerHandler.js";
@@ -79,12 +80,40 @@ discordClient.once("clientReady", async (client: Client<true>) => {
   }
 
   try {
+    console.log(
+      "[VC Recovery] Closing orphaned voice sessions from previous run...",
+    );
+    const now = new Date();
+    const openSessions = await db.query.voiceSessions.findMany({
+      where: isNull(voiceSessions.endTime),
+    });
+
+    if (openSessions.length > 0) {
+      for (const session of openSessions) {
+        const durationSeconds = Math.floor(
+          (now.getTime() - session.startTime.getTime()) / 1000,
+        );
+        await db
+          .update(voiceSessions)
+          .set({
+            endTime: now,
+            durationSeconds,
+            totalUniqueParticipants: null,
+          })
+          .where(eq(voiceSessions.id, session.id));
+      }
+      console.log(
+        `[VC Recovery] Closed ${openSessions.length} orphaned sessions.`,
+      );
+    } else {
+      console.log("[VC Recovery] No orphaned sessions found.");
+    }
+
     console.log("[VC Recovery] Reconciling active voice sessions...");
     await db.delete(activeVcSessions);
 
     const guild = await client.guilds.fetch(config.ids.guild);
     const voiceStates = guild.voiceStates.cache;
-    const now = new Date();
 
     if (voiceStates.size > 0) {
       const activeSessions: (typeof activeVcSessions.$inferInsert)[] = [];

--- a/src/listeners/voice/voiceStateUpdate/index.ts
+++ b/src/listeners/voice/voiceStateUpdate/index.ts
@@ -3,7 +3,7 @@ import {
   type GuildTextBasedChannel,
   type VoiceState,
 } from "discord.js";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { config } from "../../../config/env.js";
 import { Colors } from "../../../constants/Colors.js";
 import { db } from "../../../db/index.js";
@@ -14,8 +14,15 @@ import {
   dailyUserStats,
   hourlyActivity,
   users,
+  voiceSessionParticipants,
+  voiceSessions,
 } from "../../../db/schema.js";
 import { createListener } from "../../../utils/builders/listenerBuilder.js";
+
+const activeChannelSessions = new Map<
+  string,
+  { sessionId: number; participants: Set<string> }
+>();
 
 /**
  * Formats milliseconds into a human-readable string (e.g., "1時間3分5秒").
@@ -161,28 +168,127 @@ const logStreamSession = async (
 };
 
 export default createListener(
-  "voiceChannelLoggerAndStats",
+  "voiceStateUpdate",
   "voiceStateUpdate",
   async (oldState: VoiceState, newState: VoiceState) => {
     if (newState.guild.id === config.ids.testGuild) {
       return;
     }
+    const member = newState.member || oldState.member;
+    if (!member || member.user.bot) return;
+    const userId = member.id;
+
+    try {
+      // --- User Joins or Moves INTO a channel ---
+      if (newState.channelId && newState.channelId !== oldState.channelId) {
+        if (newState.channel && newState.channel.members.size === 1) {
+          const newSession = await db
+            .insert(voiceSessions)
+            .values({
+              channelId: newState.channelId,
+              startTime: new Date(),
+            })
+            .returning({ id: voiceSessions.id });
+          if (newSession.length > 0) {
+            const sessionId = newSession[0].id;
+            activeChannelSessions.set(newState.channelId, {
+              sessionId,
+              participants: new Set(newState.channel.members.map((m) => m.id)),
+            });
+          }
+        } else if (newState.channel) {
+          const sessionInfo = activeChannelSessions.get(newState.channelId);
+          if (sessionInfo) {
+            sessionInfo.participants.add(userId);
+          } else {
+            const openSession = await db.query.voiceSessions.findFirst({
+              where: and(
+                eq(voiceSessions.channelId, newState.channelId),
+                isNull(voiceSessions.endTime),
+              ),
+            });
+            if (openSession) {
+              const currentParticipants = newState.channel.members.map(
+                (m) => m.id,
+              );
+              activeChannelSessions.set(newState.channelId, {
+                sessionId: openSession.id,
+                participants: new Set(currentParticipants),
+              });
+            } else {
+              const fallbackSession = await db
+                .insert(voiceSessions)
+                .values({
+                  channelId: newState.channelId,
+                  startTime: new Date(),
+                })
+                .returning({ id: voiceSessions.id });
+              if (fallbackSession.length > 0) {
+                activeChannelSessions.set(newState.channelId, {
+                  sessionId: fallbackSession[0].id,
+                  participants: new Set(
+                    newState.channel.members.map((m) => m.id),
+                  ),
+                });
+              }
+            }
+          }
+        }
+      }
+
+      // --- User Leaves or Moves FROM a channel ---
+      if (oldState.channelId && oldState.channelId !== newState.channelId) {
+        if (oldState.channel && oldState.channel.members.size === 0) {
+          const sessionInfo = activeChannelSessions.get(oldState.channelId);
+          if (sessionInfo) {
+            const endTime = new Date();
+            const sessionRecord = await db.query.voiceSessions.findFirst({
+              where: eq(voiceSessions.id, sessionInfo.sessionId),
+            });
+            if (sessionRecord) {
+              const durationSeconds = Math.floor(
+                (endTime.getTime() - sessionRecord.startTime.getTime()) / 1000,
+              );
+              const uniqueParticipants = Array.from(sessionInfo.participants);
+              await db
+                .update(voiceSessions)
+                .set({
+                  endTime,
+                  durationSeconds,
+                  totalUniqueParticipants: uniqueParticipants.length,
+                })
+                .where(eq(voiceSessions.id, sessionInfo.sessionId));
+              if (uniqueParticipants.length > 0) {
+                await db
+                  .insert(voiceSessionParticipants)
+                  .values(
+                    uniqueParticipants.map((uid) => ({
+                      sessionId: sessionInfo.sessionId,
+                      userId: uid,
+                    })),
+                  )
+                  .onConflictDoNothing();
+              }
+            }
+            activeChannelSessions.delete(oldState.channelId);
+          }
+        }
+      }
+    } catch (e) {
+      console.error("Error in new voice session tracking logic:", e);
+    }
 
     const logChannelId = process.env.VOICE_LOG_CHANNEL_ID;
     if (!logChannelId) return;
 
-    const member = newState.member || oldState.member;
-    if (!member || member.user.bot) return;
+    const username = member.user.username;
+    const now = new Date();
 
     const fetched = await newState.client.channels
       .fetch(logChannelId)
       .catch(() => null);
     if (!fetched || !fetched.isTextBased()) return;
     const logChannel = fetched as GuildTextBasedChannel;
-
-    const userId = member.id;
-    const username = member.user.username;
-    const now = new Date();
 
     const embed = new EmbedBuilder()
       .setAuthor({

--- a/src/utils/helpers/activityHelper.ts
+++ b/src/utils/helpers/activityHelper.ts
@@ -7,14 +7,18 @@ import {
   type InteractionReplyOptions,
   StringSelectMenuBuilder,
 } from "discord.js";
-import { and, countDistinct, gte, sql, sum } from "drizzle-orm";
+import { and, countDistinct, gte, isNotNull, sql, sum } from "drizzle-orm";
 import {
   getMockActivityData,
   type MessageActivityData,
   type VoiceActivityData,
 } from "../../commands/slash/stats/activity/activity.mock.js";
 import { db } from "../../db/index.js";
-import { dailyUserStats, hourlyActivity } from "../../db/schema.js";
+import {
+  dailyUserStats,
+  hourlyActivity,
+  voiceSessions,
+} from "../../db/schema.js";
 import {
   generateMessageActivityImage,
   generateVoiceActivityImage,
@@ -39,7 +43,6 @@ const fetchActivityData = async (
   const dateCondition =
     timeframe === "all" ? undefined : gte(hourlyActivity.date, startDateString);
 
-  // Fetch hourly aggregate data (Messages or VC Hours)
   const hourlyResults = await db
     .select({
       hour: hourlyActivity.hour,
@@ -52,7 +55,6 @@ const fetchActivityData = async (
     .where(dateCondition)
     .groupBy(hourlyActivity.hour);
 
-  // Convert UTC hours from DB to JST hours for the chart
   const jstHourlyData = Array(24).fill(0);
   for (const result of hourlyResults) {
     const utcHour = result.hour;
@@ -60,41 +62,29 @@ const fetchActivityData = async (
     jstHourlyData[jstHour] = result.total;
   }
 
-  // --- Calculate Average Participants ---
   let averageParticipants = 0;
 
-  // New logic for Voice: Average of daily distinct participants
   if (category === "voice") {
-    const dailyCountsSubquery = db
-      .select({
-        // No need to select date here, just the daily count
-        dailyCount: countDistinct(dailyUserStats.userId).as("daily_count"),
-      })
-      .from(dailyUserStats)
-      .where(
-        and(
-          // Apply date condition directly
-          timeframe === "all"
-            ? undefined
-            : gte(dailyUserStats.date, startDateString),
-          gte(dailyUserStats.vcHours, 0.001), // Condition for voice participation
-        ),
-      )
-      .groupBy(dailyUserStats.date) // Group by date to count distinct users *per day*
-      .as("daily_counts");
-
-    // Calculate the average of these daily counts
     const avgResult = await db
       .select({
-        average: sql<number>`avg(${dailyCountsSubquery.dailyCount})`.mapWith(
-          Number,
-        ),
+        average:
+          sql<number>`avg(${voiceSessions.totalUniqueParticipants})`.mapWith(
+            Number,
+          ),
       })
-      .from(dailyCountsSubquery);
+      .from(voiceSessions)
+      .where(
+        and(
+          timeframe === "all"
+            ? undefined
+            : gte(voiceSessions.startTime, startDate),
+          isNotNull(voiceSessions.endTime),
+          isNotNull(voiceSessions.totalUniqueParticipants),
+        ),
+      );
 
     averageParticipants = avgResult[0]?.average ?? 0;
   } else {
-    // Original logic for Message: Total unique participants / days
     const participantResults = await db
       .select({
         count: countDistinct(dailyUserStats.userId),
@@ -105,16 +95,14 @@ const fetchActivityData = async (
           timeframe === "all"
             ? undefined
             : gte(dailyUserStats.date, startDateString),
-          gte(dailyUserStats.messages, 1), // Condition for message participation
+          gte(dailyUserStats.messages, 1),
         ),
       );
     const totalParticipants = participantResults[0]?.count ?? 0;
-    // Keep the simple day calculation for messages
     const numberOfDays = timeframe === "all" ? 9999 : parseInt(timeframe, 10);
-    averageParticipants = totalParticipants / Math.max(numberOfDays, 1); // Avoid division by zero
+    averageParticipants = totalParticipants / Math.max(numberOfDays, 1);
   }
 
-  // --- Calculate Total Value (Messages or VC Hours) ---
   const totalSumResult = await db
     .select({
       total:
@@ -123,25 +111,23 @@ const fetchActivityData = async (
           : sum(hourlyActivity.vcHours),
     })
     .from(hourlyActivity)
-    .where(dateCondition); // Use the same dateCondition as hourlyResults
+    .where(dateCondition);
 
   const totalValue = Number(totalSumResult[0]?.total ?? 0);
-  const peakIndex = jstHourlyData.indexOf(Math.max(...jstHourlyData, 0)); // Ensure peakIndex is found even if all data is 0
+  const peakIndex = jstHourlyData.indexOf(Math.max(...jstHourlyData, 0));
 
-  // --- Return structured data ---
   if (category === "message") {
     return {
       hourlyActivity: jstHourlyData,
       totalMessages: totalValue,
-      averageParticipants, // Use calculated average
+      averageParticipants,
       mostActiveHour: peakIndex,
     };
   }
-  // category === 'voice'
   return {
     hourlyActivity: jstHourlyData,
     totalDurationHours: totalValue,
-    averageParticipants, // Use calculated average
+    averageParticipants,
     peakHour: peakIndex,
   };
 };


### PR DESCRIPTION
## Outline

### Summary

Introduce a detailed voice session tracking system to record duration and participant data for each voice call.

### Changes & Enhancements

* **Type of Change:**
  * [x] Feature
  * [ ] Bugfix
  * [x] Refactor
  * [ ] Chore

* **Changes:**
  * **(Schema: db/schema.ts):**
    * Adds `voiceSessions` table to log start time, end time, duration, and total unique participants.
    * Adds `voiceSessionParticipants` table to link users to specific voice sessions.
  * **(Listener: voiceStateUpdate):**
    * Implements logic to create a session when the first user joins a voice channel and close it when the last user leaves.
    * Tracks all unique participants throughout a session's lifetime.
    * Records final session statistics and participant lists to the database upon completion.
  * **(Core: index.ts):**
    * Adds a recovery process on startup to find and close any voice sessions left open from a previous run.
  * **(Helper: activityHelper):**
    * Refactors average voice participant calculation to use data from the new `voiceSessions` table.

### Not Doing

---

### Other (Remarks)

---

### Checklists

- [ ] Code is well-documented (comments, JSDoc, etc.).
- [ ] Existing comments were updated as needed.
- [x] No out-of-scope changes are included.
- [ ] Write TODO comments where future work is required.
- [ ] Removed unnecessary debug code (e.g., `console.log`, `debugger`).
- [ ] Self-reviewed and tested locally.
