### PR TITLE
Send plain text welcome template

### DIFF
--- a/dist/listeners/message/introductionMessage/index.js
+++ b/dist/listeners/message/introductionMessage/index.js
@@ -222,16 +222,18 @@ export default createListener("welcomeMessageFormatChecker", "messageCreate", as
                     }
                 }
             }
-            const stickyEmbed = new EmbedBuilder()
-                .setColor(Colors.green)
-                .setTitle("自己紹介へようこそ！")
-                .setDescription(`以下のテンプレートを使用して自己紹介をお願いします：\n\`\`\`\n${CORRECT_TEMPLATE_STRING}\n\`\`\``)
-                .setFooter({
-                text: "このメッセージは新しい自己紹介が投稿されると更新されます。",
-            });
+            // const stickyEmbed = new EmbedBuilder()
+            //   .setColor(Colors.green)
+            //   .setTitle("自己紹介へようこそ！")
+            //   .setDescription(
+            //     `以下のテンプレートを使用して自己紹介をお願いします：\n\`\`\`\n${CORRECT_TEMPLATE_STRING}\n\`\`\``,
+            //   )
+            //   .setFooter({
+            //     text: "このメッセージは新しい自己紹介が投稿されると更新されます。",
+            //   });
             if (channelPermissions.has(PermissionsBitField.Flags.SendMessages)) {
                 const newStickyMessage = await channel.send({
-                    embeds: [stickyEmbed],
+                    content: CORRECT_TEMPLATE_STRING,
                 });
                 await setStickyMessageId(newStickyMessage.id);
             }

--- a/src/listeners/message/introductionMessage/index.ts
+++ b/src/listeners/message/introductionMessage/index.ts
@@ -336,19 +336,19 @@ export default createListener(
           }
         }
 
-        const stickyEmbed = new EmbedBuilder()
-          .setColor(Colors.green)
-          .setTitle("自己紹介へようこそ！")
-          .setDescription(
-            `以下のテンプレートを使用して自己紹介をお願いします：\n\`\`\`\n${CORRECT_TEMPLATE_STRING}\n\`\`\``,
-          )
-          .setFooter({
-            text: "このメッセージは新しい自己紹介が投稿されると更新されます。",
-          });
+        // const stickyEmbed = new EmbedBuilder()
+        //   .setColor(Colors.green)
+        //   .setTitle("自己紹介へようこそ！")
+        //   .setDescription(
+        //     `以下のテンプレートを使用して自己紹介をお願いします：\n\`\`\`\n${CORRECT_TEMPLATE_STRING}\n\`\`\``,
+        //   )
+        //   .setFooter({
+        //     text: "このメッセージは新しい自己紹介が投稿されると更新されます。",
+        //   });
 
         if (channelPermissions.has(PermissionsBitField.Flags.SendMessages)) {
           const newStickyMessage = await channel.send({
-            embeds: [stickyEmbed],
+            content: CORRECT_TEMPLATE_STRING,
           });
           await setStickyMessageId(newStickyMessage.id);
         }


### PR DESCRIPTION
## Outline

### Summary

Changes the introduction sticky message to post only the required template in plain text while preserving the previous welcome embed code as comments.

### Changes & Enhancements

*   **Type of Change:**
    * [x] Feature
    * [ ] Bugfix
    * [ ] Refactor
    * [ ] Chore

*   **Changes:**
    * **(Listener: introductionMessage):**
        *   Comments out the existing welcome embed without deleting it.
        *   Sends `CORRECT_TEMPLATE_STRING` as the complete sticky message content.
        *   Removes extra instructions, formatting characters, and embed content from the sticky message.

---

### Not Doing

***

### Other (Remarks)

***

### Checklists

-   [ ] Code is well-documented (comments, JSDoc, etc.).
-   [ ] Existing comments were updated as needed.
-   [x] No out-of-scope changes are included.
-   [ ] Write TODO comments where future work is required.
-   [ ] Removed unnecessary debug code (e.g., `console.log`, `debugger`).
-   [x] Self-reviewed and tested locally.